### PR TITLE
Added support for types fetch instead of simple tablename array, used for secondemain/bouclier

### DIFF
--- a/src/components/Filter/TypeFilter/TypeFilter.jsx
+++ b/src/components/Filter/TypeFilter/TypeFilter.jsx
@@ -16,13 +16,17 @@ const TypeFilter = ({ resetFiltersFlag }) => {
     iconsRefs.current[type] = element;
   };
 
-  const handleImageClick = (typeName, typesIds) => {
+  const handleImageClick = (typeName, typesIds, tablename) => {
     if (selectedTypesRefs.current.some((obj) => obj.typeName === typeName)) {
       selectedTypesRefs.current = selectedTypesRefs.current.filter(
         (obj) => obj.typeName !== typeName
       );
     } else {
-      selectedTypesRefs.current.push({ typeName: typeName, typesIds: typesIds });
+      selectedTypesRefs.current.push({
+        typeName: typeName,
+        typesIds: typesIds,
+        tablename: tablename,
+      });
     }
 
     const iconRef = iconsRefs.current[typeName];
@@ -84,7 +88,9 @@ const TypeFilter = ({ resetFiltersFlag }) => {
         {Object.keys(tablenames).map((typeName) => (
           <div
             key={typeName}
-            onClick={() => handleImageClick(typeName, tablenames[typeName].types)}
+            onClick={() =>
+              handleImageClick(typeName, tablenames[typeName].types, tablenames[typeName].tablename)
+            }
             data-image-name={typeName}
             ref={(element) => setIconsRefs(typeName, element)}
             className={cssModule["icon-container"]}

--- a/src/data/files_length.json
+++ b/src/data/files_length.json
@@ -10,7 +10,7 @@
     "casque.json": 828,
     "ceinture.json": 632,
     "emblemes.json": 636,
-    "epaulettes.json": 91114,
+    "epaulettes.json": 636,
     "equipmentItemTypes.json": 91114,
     "familiers.json": 91114,
     "harvestLoots.json": 91114,
@@ -27,6 +27,6 @@
     "recipes.json": 5161,
     "ressources.json": 91114,
     "ressourceTypes.json": 91114,
-    "secondemain.json": 125,
+    "secondemain.json": 278,
     "states.json": 91114
 }


### PR DESCRIPTION
Added array of itemTypeId to each type passed to fetchData and checkDataExists, used to make tables with multiple unique items types be queried separately

Such as secondemain.json witch contains both secondemain and boucliers : [112, 189].

